### PR TITLE
Add installer disk feature

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,7 +5,8 @@
 - [Tutorials](./tutorials/README.md)
 - [How-to guides](./how-to/README.md)
   - [How to install ox](./how-to/how-to-install-ox.md)
-  <!-- - [How to create an installer disk](./how-to/how-to-create-an-installer-disk.md) -->
+  - [How to create an installer disk](./how-to/how-to-create-an-installer-disk.md)
+  - [How to use an installer disk](./how-to/how-to-use-an-installer-disk.md)
 - [Reference materials](./reference-materials/README.md)
   - [Data flow](./reference-materials/data-flow.md)
   - [Marshal state machines](./reference-materials/marshal-state-machines.md)

--- a/docs/src/how-to/how-to-create-an-installer-disk.md
+++ b/docs/src/how-to/how-to-create-an-installer-disk.md
@@ -1,0 +1,17 @@
+# How to create an installer disk
+
+## You will need
+
+- A computercraft computer with `ox` installed ([how to install `ox`](./how-to-install-ox.md))
+- A disk drive
+- A floppy disk
+
+## Complete the following steps
+
+1. Place the disk drive directly adjacent to the computer
+2. Insert the disk into the disk drive
+3. Type and run the following command---
+   ```bash
+   ox flash
+   ```
+   You should see that the disk is now called `ox-installer`.

--- a/docs/src/how-to/how-to-install-ox.md
+++ b/docs/src/how-to/how-to-install-ox.md
@@ -6,7 +6,7 @@
 
 ## You will need
 
-- A computer block
+- A computercraft computer
 - An internet connection
 
 ## Complete the following steps

--- a/docs/src/how-to/how-to-use-an-installer-disk.md
+++ b/docs/src/how-to/how-to-use-an-installer-disk.md
@@ -1,0 +1,15 @@
+# How to use an installer disk
+
+## You will need
+
+- A computercraft computer
+- A disk drive
+- An installer disk ([how to create one](./how-to-create-an-installer-disk.md))
+
+## Complete the following steps
+
+1. Switch off the computer
+2. Place the drive directly adjacent to the computer
+3. Insert the disk into the disk drive
+4. Open the computer
+5. Follow the instructions on screen.

--- a/ox.yue
+++ b/ox.yue
@@ -18,6 +18,7 @@ import 'ox.cmd.declare'
 import 'ox.cmd.disable'
 import 'ox.cmd.edit'
 import 'ox.cmd.enable'
+import 'ox.cmd.flash'
 import 'ox.cmd.init'
 import 'ox.cmd.start'
 import 'ox.cmd.upgrade'
@@ -74,6 +75,8 @@ run = (args) ->
     disable.main args.disable
   else if args.edit?
     edit.main args.edit
+  else if args.flash?
+    flash.main args.flash
   else if args.declare?
     declare.main args.declare
   else if args.upgrade?

--- a/ox/args.yue
+++ b/ox/args.yue
@@ -49,6 +49,7 @@ export class Args
       \add (require 'ox.cmd.disable').subcommand
       \add (require 'ox.cmd.edit').subcommand
       \add (require 'ox.cmd.enable').subcommand
+      \add (require 'ox.cmd.flash').subcommand
       \add (require 'ox.cmd.init').subcommand
       \add (require 'ox.cmd.start').subcommand
       \add (require 'ox.cmd.upgrade').subcommand

--- a/ox/cmd/flash.yue
+++ b/ox/cmd/flash.yue
@@ -1,0 +1,172 @@
+local *
+
+import 'clap' as :Param, :Subcommand
+import 'ox.peripheral.drive' as :Drive
+import 'quicktype' as :declare_type, :F
+import 'spec' as :spec
+
+export subcommand = with Subcommand 'flash'
+  \description 'create an installer disk'
+  \add with Param 'drive'
+    \description 'the drive containing the disk to flash. If omitted, ox searches for a drive'
+    \default nil
+
+declare_type 'FlashArgs', [[{
+  drive: ?string,
+}]]
+export main = F '(FlashArgs) -> <>', (args) ->
+  { :drive } = args
+
+  try
+    flasher = OxFlasher Drive drive
+    flasher\flash!
+  catch err
+    print err
+  return
+
+class OxFlasher
+  new: F '(Drive) => <>', (@drive) =>
+
+  @label: 'ox installer'
+
+  flash: F '() => <>', =>
+    if not @drive\set_disk_label @@label
+      error 'cannot flash disk: cannot set disk label'
+    current_label = @drive\disk_label!
+    if not current_label?
+      error 'cannot flash disk: no disk present'
+    if current_label != @@label
+      error 'cannot flash disk: cannot set disk label'
+
+    mount_path = @drive\mount_path!
+    if not mount_path?
+      error 'cannot flash disk: not mounted'
+    ox_content = do
+      with assert io.open 'ox', 'r'
+        ox_content = assert \read '*a'
+        assert \close!
+      ox_content
+
+    startup_script_content = startup_script @@label
+
+    disk_free_space = fs.getFreeSpace mount_path
+    required_disk_space = #ox_content + #startup_script_content
+    if disk_free_space < required_disk_space
+      error "cannot flash disk: insufficient space, need #{required_disk_space}B but only #{disk_free_space}B available"
+
+    with assert io.open "#{mount_path}/ox", 'w+'
+      assert \write ox_content
+      assert \close!
+
+    with assert io.open "#{mount_path}/startup.lua", 'w+'
+      assert \write startup_script_content
+      assert \close!
+    return
+
+startup_script = F '(string) -> string', (label) ->
+  lines =
+    * "term.clear()"
+    * "term.setCursorPos(1, 1)"
+    * "local installer_header = '--- ox installer ---'"
+    * "print(('-'):rep(#installer_header))"
+    * "print(installer_header)"
+    * "print(('-'):rep(#installer_header))"
+    * "print('')"
+    * "print('Welcome to the ox installer!')"
+    * "while true do"
+    * "  print('')"
+    * "  print('Options:')"
+    * "  print(\"* To install ox, type `y' then hit <enter>\")"
+    * "  print(\"* To cancel, type `n' then hit <enter>\")"
+    * "  print('')"
+    * "  io.write('> ')"
+    * "  local resp = io.read('*l'):sub(1, 1):lower()"
+    * "  print('')"
+    * ""
+    * "  if resp == 'y' then"
+    * "    break"
+    * "  elseif resp == 'n' then"
+    * "    print('aborting install')"
+    * "    return"
+    * "  end"
+    * "  print('! response \\'' .. resp .. '\\' unrecognised')"
+    * "end"
+    * ""
+    * "local disk_mount_path = nil"
+    * "do"
+    * "  disk_drive = peripheral.find('drive', function(_, drive)"
+    * "    disk_mount_path = drive.getMountPath()"
+    * "    return drive.getDiskLabel() == '#{label}'"
+    * "  end)"
+    * "end"
+    * "assert(disk_mount_path, 'unable to find disk where label=#{label}')"
+    * ""
+    * "-- Copy files"
+    * "print('Copying ' .. disk_mount_path .. '/ox -> /ox ...')"
+    * "local ox_dest = assert(io.open('ox', 'w+'))"
+    * "for line in io.lines(disk_mount_path .. '/ox') do"
+    * "  assert(ox_dest:write(line))"
+    * "  assert(ox_dest:write('\\n'))"
+    * "end"
+    * "assert(ox_dest:close())"
+    * "print('Done!')"
+  table.concat lines, '\n'
+
+spec ->
+  import 'spec_macros' as $
+
+  import 'spec' as :describe, :it, :matchers
+
+  import eq from matchers
+
+  describe 'startup_script', ->
+    it 'has expected value', ->
+      LABEL = 'expected_label'
+      expected_lines =
+        * "term.clear()"
+        * "term.setCursorPos(1, 1)"
+        * "local installer_header = '--- ox installer ---'"
+        * "print(('-'):rep(#installer_header))"
+        * "print(installer_header)"
+        * "print(('-'):rep(#installer_header))"
+        * "print('')"
+        * "print('Welcome to the ox installer!')"
+        * "while true do"
+        * "  print('')"
+        * "  print('Options:')"
+        * "  print(\"* To install ox, type `y' then hit <enter>\")"
+        * "  print(\"* To cancel, type `n' then hit <enter>\")"
+        * "  print('')"
+        * "  io.write('> ')"
+        * "  local resp = io.read('*l'):sub(1, 1):lower()"
+        * "  print('')"
+        * ""
+        * "  if resp == 'y' then"
+        * "    break"
+        * "  elseif resp == 'n' then"
+        * "    print('aborting install')"
+        * "    return"
+        * "  end"
+        * "  print('! response \\'' .. resp .. '\\' unrecognised')"
+        * "end"
+        * ""
+        * "local disk_mount_path = nil"
+        * "do"
+        * "  disk_drive = peripheral.find('drive', function(_, drive)"
+        * "    disk_mount_path = drive.getMountPath()"
+        * "    return drive.getDiskLabel() == '#{LABEL}'"
+        * "  end)"
+        * "end"
+        * "assert(disk_mount_path, 'unable to find disk where label=#{LABEL}')"
+        * ""
+        * "-- Copy files"
+        * "print('Copying ' .. disk_mount_path .. '/ox -> /ox ...')"
+        * "local ox_dest = assert(io.open('ox', 'w+'))"
+        * "for line in io.lines(disk_mount_path .. '/ox') do"
+        * "  assert(ox_dest:write(line))"
+        * "  assert(ox_dest:write('\\n'))"
+        * "end"
+        * "assert(ox_dest:close())"
+        * "print('Done!')"
+      expected_content = table.concat expected_lines, '\n'
+      $expect_that (startup_script LABEL), eq expected_content

--- a/ox/cmd/flash.yue
+++ b/ox/cmd/flash.yue
@@ -29,7 +29,7 @@ class OxFlasher
 
   @label: 'ox installer'
 
-  flash: F '() => <>', =>
+  flash: F '(?string) => <>', (input_dir='')=>
     if not @drive\set_disk_label @@label
       error 'cannot flash disk: cannot set disk label'
     current_label = @drive\disk_label!
@@ -42,7 +42,7 @@ class OxFlasher
     if not mount_path?
       error 'cannot flash disk: not mounted'
     ox_content = do
-      with assert io.open 'ox', 'r'
+      with assert io.open "#{input_dir}/ox", 'r'
         ox_content = assert \read '*a'
         assert \close!
       ox_content
@@ -115,9 +115,51 @@ startup_script = F '(string) -> string', (label) ->
 spec ->
   import 'spec_macros' as $
 
+  import 'ox.peripheral.drive' as :TestDrive
   import 'spec' as :describe, :it, :matchers
 
-  import eq from matchers
+  import eq, gt, len from matchers
+
+  describe 'Flasher', ->
+    it 'flashes the given drive', ->
+      TEMP_PATH = '.test'
+      MOUNT_PATH = "#{TEMP_PATH}/mnt"
+      fs.makeDir TEMP_PATH
+      fs.makeDir MOUNT_PATH
+
+      EXPECTED_CONTENT = 'expected-content'
+
+      with assert io.open "#{TEMP_PATH}/ox", 'w+'
+        assert \write EXPECTED_CONTENT
+        assert \close!
+
+      disk_label = nil
+      flasher = OxFlasher TestDrive
+        is_disk_present: => true
+        mount_path: => MOUNT_PATH
+        disk_label: => disk_label
+        set_disk_label: (label) =>
+          disk_label = label
+          true
+      flasher\flash TEMP_PATH
+
+      ox_content = nil
+      with? io.open "#{MOUNT_PATH}/ox", 'r'
+        ox_content = assert \read '*a'
+        assert \close!
+      $expect_that ox_content, eq EXPECTED_CONTENT
+
+      startup_content = nil
+      with? io.open "#{MOUNT_PATH}/startup.lua", 'r'
+        startup_content = assert \read '*a'
+        assert \close!
+      $expect_that startup_content, len gt 0
+
+      assert os.remove "#{MOUNT_PATH}/ox"
+      assert os.remove "#{MOUNT_PATH}/startup.lua"
+      assert os.remove MOUNT_PATH
+      assert os.remove "#{TEMP_PATH}/ox"
+      assert os.remove TEMP_PATH
 
   describe 'startup_script', ->
     it 'has expected value', ->

--- a/ox/peripheral/drive.yue
+++ b/ox/peripheral/drive.yue
@@ -3,7 +3,12 @@ local MinecraftBackend
 
 import 'quicktype' as :declare_type, :F
 
-declare_type 'Drive', [[{}]]
+declare_type 'Drive', [[{
+  is_disk_present: () => boolean,
+  mount_path: () => ?string,
+  disk_label: () => ?string,
+  set_disk_label: (?string) => boolean,
+}]]
 export class Drive
   new: F '(?string) => <>', (direction) =>
     local drive
@@ -31,7 +36,7 @@ export class Drive
   disk_label: F '() => ?string', =>
     @drive.getDiskLabel!
 
-  set_disk_label: F '(string) => boolean', (label) =>
+  set_disk_label: F '(?string) => boolean', (label) =>
     local ret
     try
       @drive.setDiskLabel label
@@ -39,3 +44,22 @@ export class Drive
     catch _
       ret = false
     ret
+
+declare_type 'TestDriveOpts', [[{
+  is_disk_present: ?() => boolean,
+  mount_path: ?() => ?string,
+  disk_label: ?() => ?string,
+  set_disk_label: ?(?string) => boolean,
+}]]
+export class TestDrive
+  new: F '(TestDriveOpts) => <>', (opts) =>
+    {
+      :is_disk_present=-> error "is_disk_present unimplemented"
+      :mount_path=-> error "mount_path unimplemented"
+      :disk_label=-> error "disk_label unimplemented"
+      :set_disk_label=-> error "set_disk_label unimplemented"
+    } = opts
+    @is_disk_present = is_disk_present
+    @mount_path = mount_path
+    @disk_label = disk_label
+    @set_disk_label = set_disk_label

--- a/ox/peripheral/drive.yue
+++ b/ox/peripheral/drive.yue
@@ -1,0 +1,41 @@
+local *
+local MinecraftBackend
+
+import 'quicktype' as :declare_type, :F
+
+declare_type 'Drive', [[{}]]
+export class Drive
+  new: F '(?string) => <>', (direction) =>
+    local drive
+    if direction?
+      if 'drive' != peripheral.getType direction
+        error "no drive attached to #{direction}"
+      drive = peripheral.wrap direction
+      if not drive?
+        error "no drive attached to #{direction}"
+    else
+      drives = { peripheral.find 'drive' }
+      if #drives == 0
+        error 'no drives attached'
+      if #drives > 1
+        error 'too many drives attached'
+      drive = drives[1]
+    @drive = drive
+
+  is_disk_present: F '() => boolean', =>
+    @drive.isDiskPresent!
+
+  mount_path: F '() => ?string', =>
+    @drive.getMountPath!
+
+  disk_label: F '() => ?string', =>
+    @drive.getDiskLabel!
+
+  set_disk_label: F '(string) => boolean', (label) =>
+    local ret
+    try
+      @drive.setDiskLabel label
+      ret = true
+    catch _
+      ret = false
+    ret


### PR DESCRIPTION
This PR improves the ergonomics of setting up a cluster of `ox` computers by allowing the user to create 'installer disks,' which, when placed into a drive next to a computer, will run an installer for `ox` on that computer on startup
